### PR TITLE
DCT shiftUp/Down Fix

### DIFF
--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -45,9 +45,9 @@ local function applyGear(data) --TODO: add handling for mismatched gearbox types
 		local remoteIndex = tonumber(string.sub(data, 2))
 		if remoteGearMode == 'M' and localGearMode == 'M' then
 			if electrics.values.gearIndex < remoteIndex then
-				controller.mainController.shiftUp()
+				controller.mainController.shiftUpOnDown()
 			elseif electrics.values.gearIndex > remoteIndex then
-				controller.mainController.shiftDown()
+				controller.mainController.shiftDownOnUp()
 			end
 		else
 			controller.mainController.shiftToGearIndex(translationTable[remoteGearMode])


### PR DESCRIPTION
Related
https://github.com/BeamMP/BeamMP/issues/389

Issue
https://github.com/BeamMP/BeamMP/blob/development/lua/vehicle/extensions/BeamMP/MPInputsVE.lua#L48

The shiftUp and shiftDown functions no longer exists. The game now defines
- shiftDownOnUp
- shiftDownOnDown
- shiftUpOnDown
- shiftUpOnUp

While i cant quite tell what they really mean from reading a bit of code, swapping shiftUp with shiftUpOnDown and shiftDown with shiftDownOnUp solved this issue.

I replicated this bug with the help of my replay tool and checked that DCT manual shifts are successfully applied.

This may not be the final solution for the new game shift logic.